### PR TITLE
Added TGMS Bookmarks add-on

### DIFF
--- a/ActionFiles/V1/TGMS_Bookmarks.act
+++ b/ActionFiles/V1/TGMS_Bookmarks.act
@@ -1,0 +1,33 @@
+ACTIONFILE V4
+
+ENABLED True
+
+INSTALL LongDescription="Simple macros that allows you to create a bookmark named after the system you jumped into by hitting the scroll lock key"
+INSTALL ShortDescription="TGMS Bookmarks"
+INSTALL Version=1.0.0.0
+INSTALL MinEDVersion=8.1.0.0
+INSTALL Location=Actions
+
+EVENT FSDJump, FSDResponse, "", Condition AlwaysTrue
+EVENT onKeyPress, BookmarkSystem, "", KeyPress $== Scroll
+
+//*************************************************************
+// FSDResponse
+// Events: FSDJump
+//*************************************************************
+PROGRAM FSDResponse
+
+Static TGMS_StarSystem = %(EventClass_StarSystem)
+
+END PROGRAM
+
+//*************************************************************
+// BookmarkSystem
+// Events: onKeyPress?(KeyPress $== Scroll)
+//*************************************************************
+PROGRAM BookmarkSystem
+
+Bookmarks ADDSTAR "%(TGMS_StarSystem)"
+
+END PROGRAM
+

--- a/ActionFiles/V1/TGMS_Bookmarks.act
+++ b/ActionFiles/V1/TGMS_Bookmarks.act
@@ -8,18 +8,7 @@ INSTALL Version=1.0.0.0
 INSTALL MinEDVersion=8.1.0.0
 INSTALL Location=Actions
 
-EVENT FSDJump, FSDResponse, "", Condition AlwaysTrue
 EVENT onKeyPress, BookmarkSystem, "", KeyPress $== Scroll
-
-//*************************************************************
-// FSDResponse
-// Events: FSDJump
-//*************************************************************
-PROGRAM FSDResponse
-
-Static TGMS_StarSystem = %(EventClass_StarSystem)
-
-END PROGRAM
 
 //*************************************************************
 // BookmarkSystem
@@ -27,7 +16,9 @@ END PROGRAM
 //*************************************************************
 PROGRAM BookmarkSystem
 
-Bookmarks ADDSTAR "%(TGMS_StarSystem)"
+Event Last
+
+Bookmarks ADDSTAR "%(EC_StarSystem)"
 
 END PROGRAM
 


### PR DESCRIPTION
This is an add-on that enables the user to create a bookmark to the last system they jumped to by pressing the scroll lock key.

The purpose of this add-on is to make it easy to bookmark lists of systems for scientific surveys. This add-on was created to support the Trans-Galactic Metallicity Survey (https://docs.google.com/document/d/1goLsusHMlS8aExuHwnqfbCyV4EX3GSG8_Acrrkab_qM/edit?usp=sharing), part of the upcoming Distant Worlds 2 expedition.