### PR TITLE
First version of CmdrLogs, an Action Pack which can be used to popula…

### DIFF
--- a/ActionFiles/V1/CmdrLog.act
+++ b/ActionFiles/V1/CmdrLog.act
@@ -4,7 +4,7 @@ ENABLED True
 
 INSTALL LongDescription="This pack allows you to add System Notes using the in-game chat window.\r\nSend a message to \"Local\" prefixed with \"LOG\" and it will be appended to your System Notes.\r\n\r\nYou can edit the Prefix in the \"Globals\" section in \"Edit Add-on Action Files\", or via the \"Commanders Log\" preferences dialog in the \"Add-Ons\" menu."
 INSTALL ShortDescription="Commanders Log"
-INSTALL Version=1.0.0.0
+INSTALL Version=1.0.0.1
 INSTALL MinEDVersion=10.4.3.0
 INSTALL Location=Actions
 
@@ -60,14 +60,14 @@ PROGRAM onSendText
 // TODO: Use event condition instead of these checks
 // TODO: Allow user to specify which Chat Channel(s) to use for log messages
 If EventClass_To $!= Local
-    Pragma log "Ignoring message as not to Local"
+    Pragma Debug "Ignoring message as not to \"Local\""
     Return 
 
 // Pragma dumpvars EventClass_Message
 // Pragma dumpvars CmdrLog*
 Let len = %Length(CmdrLogPrefix)
 If %substring(EventClass_Message,0,len) CS!= %(CmdrLogPrefix)
-    Pragma log "Ignoring message as does not start with %(CmdrLogPrefix)"
+    Pragma Debug "Ignoring message as not starting with %(CmdrLogPrefix)"
     Return 
 
 // Retrieve details for the current History entry (into EC_ variables)
@@ -130,7 +130,6 @@ END PROGRAM
 //*************************************************************
 PROGRAM onMenuItem
 
-Pragma Log "Menu clicked"
 // Row 1 - y = 30, height = 20
 Set dvar_l1 = "L1,Label,\"Prefix\",10,30,100,20,,"
 Set dvar_tb1 = "TB1,TextBox,%(CmdrLogPrefix),120,30,200,20,\"Specify the prefix to use when sending a message.\",0"
@@ -144,19 +143,18 @@ Dialog D1, "Commanders Log", "350,100", dvar
 While (D1 $!= OK) And (D1 $!= Cancel)
     Print %(D1)
     // If D1 $== B1
-    // Print Button B1
-    // DialogControl D1,Set TB1="Hello there"
+        // Print Button B1
+        // DialogControl D1,Set TB1="Hello there"
     DialogControl D1,Continue
 
 If D1 $== OK
     DialogControl D1,Get TB1
-    Print textbox=%(DialogResult)
+    // Print textbox=%(DialogResult)
     PersistentGlobal CmdrLogPrefix = %(DialogResult)
-    Pragma Log "CmdrLogPrefix set to %(CmdrLogPrefix)"
+    Pragma Debug "CmdrLogPrefix set to %(CmdrLogPrefix)"
 
 DialogControl D1, Close
 
 Return 
 
 END PROGRAM
-

--- a/ActionFiles/V1/CmdrLog.act
+++ b/ActionFiles/V1/CmdrLog.act
@@ -1,0 +1,162 @@
+﻿ACTIONFILE V4
+
+ENABLED True
+
+INSTALL LongDescription="This pack allows you to add System Notes using the in-game chat window.\r\nSend a message to \"Local\" prefixed with \"LOG\" and it will be appended to your System Notes.\r\n\r\nYou can edit the Prefix in the \"Globals\" section in \"Edit Add-on Action Files\", or via the \"Commanders Log\" preferences dialog in the \"Add-Ons\" menu."
+INSTALL ShortDescription="Commanders Log"
+INSTALL Version=1.0.0.0
+INSTALL MinEDVersion=10.4.3.0
+INSTALL Location=Actions
+
+EVENT onInstall, onInstall, "", Condition AlwaysTrue
+EVENT onStartup, onStartup, "", Condition AlwaysTrue
+EVENT SendText, onSendText, "", Condition AlwaysTrue
+EVENT onMenuItem, onMenuItem, "", MenuName $== MenuCmdrLogPrefix
+
+//*************************************************************
+// init
+//*************************************************************
+PROGRAM init
+
+// Initialise the prefix
+If CmdrLogPrefix NotPresent
+    PersistentGlobal CmdrLogPrefix = LOG
+
+// Initialise the menu
+MenuItem MenuCmdrLogPrefix
+If MenuPresent IsFalse
+    MenuItem MenuCmdrLogPrefix,"add-ons","Commanders Log"
+
+END PROGRAM
+
+//*************************************************************
+// onInstall
+// Events: onInstall
+//*************************************************************
+PROGRAM onInstall
+
+Call init
+
+END PROGRAM
+
+//*************************************************************
+// onStartup
+// Events: onStartup
+//*************************************************************
+PROGRAM onStartup
+
+// Startup processing - initialize any global state
+Call init
+
+END PROGRAM
+
+//*************************************************************
+// onSendText
+// Events: SendText
+//*************************************************************
+PROGRAM onSendText
+
+// Pragma dumpvars E*
+// TODO: Use event condition instead of these checks
+// TODO: Allow user to specify which Chat Channel(s) to use for log messages
+If EventClass_To $!= Local
+    Pragma log "Ignoring message as not to Local"
+    Return 
+
+// Pragma dumpvars EventClass_Message
+// Pragma dumpvars CmdrLog*
+Let len = %Length(CmdrLogPrefix)
+If %substring(EventClass_Message,0,len) CS!= %(CmdrLogPrefix)
+    Pragma log "Ignoring message as does not start with %(CmdrLogPrefix)"
+    Return 
+
+// Retrieve details for the current History entry (into EC_ variables)
+// which is the one we actually want to update
+Event THPOS
+
+// Pragma dumpvars E*
+
+// Ideally should escape all incoming messages but we don't have a function to do this yet
+// Set Msg = %EscapeChar(EventClass_Message)
+// Set Note = %EscapeChar(EC_Note)
+
+// Pragma log "Current JID = %(EventJID)"
+// Pragma log "Target JID = %(EC_JID)"
+// Pragma log "Message = %(EventClass_Message)"
+// Pragma log "Current note = %(EC_Note)"
+
+// Strip prefix from message
+Call stripPrefix(str = "%(EventClass_Message)", prefix = "%(CmdrLogPrefix)")
+Set NewNote = %(ReturnValue)
+
+If NewNote Empty
+    Return 
+
+// Concatenate the new note to the existing one
+If EC_Note IsNotEmpty
+    Set NewNote = "%join(\"\r\n\",EC_Note,NewNote)"
+    Set NewNote = %ReplaceEscapeChar(NewNote)
+
+// Cannot use Pragma log if the note contains any special characters
+// Pragma dumpvars NewNote
+
+// Save new note to history
+If NewNote CS!= EC_Note
+    Event FROM %(EC_JID) NOTE "%(NewNote)"
+
+END PROGRAM
+
+//*************************************************************
+// stripPrefix
+//*************************************************************
+PROGRAM stripPrefix
+
+If str Empty
+    Return ""
+
+If prefix Empty
+    Return %trim(str)
+
+Let prefixLen = %length(prefix) + 1
+// substring - must use all 3 parameters, third parameter must be >= 0
+Set rv = %substring(str,prefixLen,2048)
+Return %trim(rv)
+
+END PROGRAM
+
+//*************************************************************
+// onMenuItem
+// Events: onMenuItem?(MenuName $== MenuCmdrLogPrefix)
+//*************************************************************
+PROGRAM onMenuItem
+
+Pragma Log "Menu clicked"
+// Row 1 - y = 30, height = 20
+Set dvar_l1 = "L1,Label,\"Prefix\",10,30,100,20,,"
+Set dvar_tb1 = "TB1,TextBox,%(CmdrLogPrefix),120,30,200,20,\"Specify the prefix to use when sending a message.\",0"
+// Row 2 - y = 60, height = 20
+Set dvar_ok = "OK,Button,\"OK\",10,60,100,20,\"Press for OK\""
+Set dvar_cancel = "Cancel,Button,\"Cancel\",120,60,100,20,\"Press for Cancel\""
+
+Dialog D1, "Commanders Log", "350,100", dvar
+
+// Handle other controls until OK or Cancel has been pressed
+While (D1 $!= OK) And (D1 $!= Cancel)
+    Print %(D1)
+    // If D1 $== B1
+    // Print Button B1
+    // DialogControl D1,Set TB1="Hello there"
+    DialogControl D1,Continue
+
+If D1 $== OK
+    DialogControl D1,Get TB1
+    Print textbox=%(DialogResult)
+    PersistentGlobal CmdrLogPrefix = %(DialogResult)
+    Pragma Log "CmdrLogPrefix set to %(CmdrLogPrefix)"
+
+DialogControl D1, Close
+
+Return 
+
+END PROGRAM
+

--- a/ActionFiles/V1/CmdrLog.act
+++ b/ActionFiles/V1/CmdrLog.act
@@ -22,6 +22,10 @@ PROGRAM init
 If CmdrLogPrefix NotPresent
     PersistentGlobal CmdrLogPrefix = LOG
 
+// Initialise whether to log timestamps
+If CmdrLogTimestamp NotPresent
+    PersistentGlobal CmdrLogTimestamp = 0
+
 // Initialise the menu
 MenuItem MenuCmdrLogPrefix
 If MenuPresent IsFalse
@@ -92,6 +96,11 @@ Set NewNote = %(ReturnValue)
 If NewNote Empty
     Return 
 
+// If we're logging timestamps, prefix the note
+If CmdrLogTimestamp IsTrue
+    Set now = "%DateTimeNow(\"\")"
+    Set NewNote = "%join(\" \", now, NewNote)"
+
 // Concatenate the new note to the existing one
 If EC_Note IsNotEmpty
     Set NewNote = "%join(\"\r\n\",EC_Note,NewNote)"
@@ -134,10 +143,12 @@ PROGRAM onMenuItem
 Set dvar_l1 = "L1,Label,\"Prefix\",10,30,100,20,,"
 Set dvar_tb1 = "TB1,TextBox,%(CmdrLogPrefix),120,30,200,20,\"Specify the prefix to use when sending a message.\",0"
 // Row 2 - y = 60, height = 20
-Set dvar_ok = "OK,Button,\"OK\",10,60,100,20,\"Press for OK\""
-Set dvar_cancel = "Cancel,Button,\"Cancel\",120,60,100,20,\"Press for Cancel\""
+Set dvar_cb1 = "CB1,CheckBox,\"Log Timestamps\",10,60,200,20,\"Check to add a timestamp to every log entry.\",%(CmdrLogTimestamp)"
+// Row 2 - y = 90, height = 20
+Set dvar_ok = "OK,Button,\"OK\",10,90,100,20,\"Press for OK\""
+Set dvar_cancel = "Cancel,Button,\"Cancel\",120,90,100,20,\"Press for Cancel\""
 
-Dialog D1, "Commanders Log", "350,100", dvar
+Dialog D1, "Commanders Log", "350,130", dvar
 
 // Handle other controls until OK or Cancel has been pressed
 While (D1 $!= OK) And (D1 $!= Cancel)
@@ -149,9 +160,10 @@ While (D1 $!= OK) And (D1 $!= Cancel)
 
 If D1 $== OK
     DialogControl D1,Get TB1
-    // Print textbox=%(DialogResult)
     PersistentGlobal CmdrLogPrefix = %(DialogResult)
     Pragma Debug "CmdrLogPrefix set to %(CmdrLogPrefix)"
+    DialogControl D1,Get CB1
+    PersistentGlobal CmdrLogTimestamp = %(DialogResult)
 
 DialogControl D1, Close
 


### PR DESCRIPTION
…te the System Note field using the in-game text chat.

After testing, it seems to work well enough for my purposes.

USAGE:
- Install Action Pack
- Optionally change the Prefix (either using the menu to open the preferences dialog, or via the "Globals" variables accessible through "Edit Action Pack Files")
- Inside the game, open the Chat popup and send a message to "Local" prefixing it with the prefix, by default, "LOG".
- The System Note of the currently-selected History entry will have the string following the prefix appended with a newline.

eg; 
- System note is currently "Myshka was here"
- Sent chat to Local "LOG So was Finwen"
- System note will be "Myshka was here\nSo was Finwen"


Please review and comment on coding style/bugs/issues/feature requests/etc necessary before merging.

TODO:  

1)
Let user choose which chat to use to create Log messages (set of destination channels).  Currently "Local" is hard-coded.

They might want to use another channel specifically or, more likely, any.

2)
Let user choose which event(s) to attach Log to.  Currently uses currently-selected History entry, which, by default, is auto-updated to be the most recent.

Several points here:
a. I filter my history list and only show "Jump" events.  In the case where the user has other events showing in their list (for example, during testing I also had the "Landed" event enabled), the Log will get attached to whichever event is currently selected.

b. Ideally the user should supply (a list of) events to attach Logs to; the most recent Event matching their filter would get selected and updated.

c. Instead of the currently-selected, the log entry -should- go to the most recent event matching the user selection prior to the "SendText" event creating the log instead of the currently selected one.  Although a "feature" of the current implementation is that a user can manually run the Action and add log entriess to an arbitrary event they click on.
